### PR TITLE
Add ERC20 fee reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ The frontend reads `VITE_API_BASE_URL`; if unset, it calls `/api` and relies on 
 - Optimism: `eth_estimateGas` と `eth_gasPrice` に加え、GasPriceOracle `getL1Fee` で L1 データ料を取得し合算します。
 - Arbitrum: `eth_estimateGas` の結果に L1 バッファが含まれるため、`gasPrice * estimatedGas` が総コストです。
 - Linea: `linea_estimateGas` が利用可能なら優先し、EIP-1559 価格で乗算します。
-  HTML ビューではデフォルトで JPY 換算が有効になっており、トグルから USD / JPY を切り替えられます。API 側も `fiat=usd|jpy` 指定で CoinMarketCap 由来の法定通貨建て手数料を含みます。Native 送金と併せて ERC-20 送金時の推定ガス量／手数料も同テーブルに併記します。
+  HTML ビューではデフォルトで JPY 換算が有効になっており、トグルから USD / JPY を切り替えられます。API 側も `fiat=usd|jpy` 指定で CoinMarketCap 由来の法定通貨建て手数料を含みます。Native 送金と併せて WBTC (ERC-20) 送金時の推定ガス量／手数料も同テーブルに併記します。

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ The frontend reads `VITE_API_BASE_URL`; if unset, it calls `/api` and relies on 
 - Optimism: `eth_estimateGas` と `eth_gasPrice` に加え、GasPriceOracle `getL1Fee` で L1 データ料を取得し合算します。
 - Arbitrum: `eth_estimateGas` の結果に L1 バッファが含まれるため、`gasPrice * estimatedGas` が総コストです。
 - Linea: `linea_estimateGas` が利用可能なら優先し、EIP-1559 価格で乗算します。
-  HTML ビューではデフォルトで JPY 換算が有効になっており、トグルから USD / JPY を切り替えられます。API 側も `fiat=usd|jpy` 指定で CoinMarketCap 由来の法定通貨建て手数料を含みます。
+  HTML ビューではデフォルトで JPY 換算が有効になっており、トグルから USD / JPY を切り替えられます。API 側も `fiat=usd|jpy` 指定で CoinMarketCap 由来の法定通貨建て手数料を含みます。Native 送金と併せて ERC-20 送金時の推定ガス量／手数料も同テーブルに併記します。

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -21,6 +21,7 @@ class ChainSettings(BaseModel):
     chain_id: int
     rpc_env: str
     native_gas_limit: int = Field(default=21_000, ge=21_000)
+    erc20_gas_limit: int = Field(default=55_000, ge=21_000)
     infura_network: str | None = None
     fee_model: str = Field(default="l1")
     price_symbol: str | None = None

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -22,6 +22,7 @@ class ChainSettings(BaseModel):
     rpc_env: str
     native_gas_limit: int = Field(default=21_000, ge=21_000)
     erc20_gas_limit: int = Field(default=55_000, ge=21_000)
+    erc20_token_symbol: str = Field(default="WBTC")
     infura_network: str | None = None
     fee_model: str = Field(default="l1")
     price_symbol: str | None = None

--- a/api/app/routes/fees.py
+++ b/api/app/routes/fees.py
@@ -179,6 +179,7 @@ def _ensure_erc20_shape(rows: list[dict[str, Any]], chains: list[ChainSettings])
             }
             continue
         erc20.setdefault("gas_limit", gas_limit)
+        erc20.setdefault("token_symbol", chain.erc20_token_symbol)
         fee = erc20.get("fee")
         if fee is None:
             erc20["fee"] = {"wei": None, "formatted": None}

--- a/api/app/services/gas.py
+++ b/api/app/services/gas.py
@@ -60,6 +60,7 @@ class FeeSnapshot:
             },
             "erc20": {
                 "gas_limit": self.chain.erc20_gas_limit,
+                "token_symbol": self.chain.erc20_token_symbol,
                 "fee": {
                     "wei": erc20_fee_wei,
                     "formatted": _format_decimal(erc20_fee_native, 8),
@@ -325,6 +326,7 @@ def _error_payload(chain: ChainSettings, message: str) -> Dict[str, Any]:
         "error": message,
         "erc20": {
             "gas_limit": chain.erc20_gas_limit,
+            "token_symbol": chain.erc20_token_symbol,
             "fee": {"wei": None, "formatted": None},
         },
     }

--- a/api/app/services/gas.py
+++ b/api/app/services/gas.py
@@ -40,6 +40,8 @@ class FeeSnapshot:
     def as_payload(self) -> Dict[str, Any]:
         gas_price_gwei = Decimal(self.data.gas_price_wei) / NANO
         native_fee = Decimal(self.data.native_fee_wei) / WEI
+        erc20_fee_wei = self.data.gas_price_wei * self.chain.erc20_gas_limit
+        erc20_fee_native = Decimal(erc20_fee_wei) / WEI
         return {
             "chain": {
                 "key": self.chain.key,
@@ -55,6 +57,13 @@ class FeeSnapshot:
             "native_fee": {
                 "wei": self.data.native_fee_wei,
                 "formatted": _format_decimal(native_fee, 8),
+            },
+            "erc20": {
+                "gas_limit": self.chain.erc20_gas_limit,
+                "fee": {
+                    "wei": erc20_fee_wei,
+                    "formatted": _format_decimal(erc20_fee_native, 8),
+                },
             },
             "fetched_at": int(self.fetched_at),
             "mode": self.data.mode,
@@ -314,6 +323,10 @@ def _error_payload(chain: ChainSettings, message: str) -> Dict[str, Any]:
             "chain_id": chain.chain_id,
         },
         "error": message,
+        "erc20": {
+            "gas_limit": chain.erc20_gas_limit,
+            "fee": {"wei": None, "formatted": None},
+        },
     }
 
 

--- a/api/app/templates/fees.html
+++ b/api/app/templates/fees.html
@@ -159,9 +159,9 @@
             <th>Gas Price (Gwei)</th>
             <th>ガス量</th>
             <th>手数料</th>
+            <th>法定手数料</th>
             <th>ERC20 ガス量</th>
             <th>ERC20 手数料</th>
-            <th>法定手数料</th>
             <th>モード</th>
             <th>ステータス</th>
           </tr>
@@ -186,6 +186,13 @@
               {% endif %}
             </td>
             <td>
+              {% if row.fiat_fee %}
+              {{ row.fiat_fee.formatted }} {{ row.fiat_fee.currency }}
+              {% else %}
+              —
+              {% endif %}
+            </td>
+            <td>
               {% if row.erc20 %}
               {{ row.erc20.gas_limit or '—' }}
               {% else %}
@@ -195,13 +202,6 @@
             <td>
               {% if row.erc20 and row.erc20.fee.formatted %}
               {{ row.erc20.fee.formatted }} {{ row.chain.symbol }}
-              {% else %}
-              —
-              {% endif %}
-            </td>
-            <td>
-              {% if row.fiat_fee %}
-              {{ row.fiat_fee.formatted }} {{ row.fiat_fee.currency }}
               {% else %}
               —
               {% endif %}

--- a/api/app/templates/fees.html
+++ b/api/app/templates/fees.html
@@ -162,6 +162,7 @@
             <th>法定手数料</th>
             <th>ERC20 ガス量</th>
             <th>ERC20 手数料</th>
+            <th>ERC20 法定手数料</th>
             <th>モード</th>
             <th>ステータス</th>
           </tr>
@@ -201,7 +202,14 @@
             </td>
             <td>
               {% if row.erc20 and row.erc20.fee.formatted %}
-              {{ row.erc20.fee.formatted }} {{ row.erc20.token_symbol or row.chain.symbol }}
+              {{ row.erc20.fee.formatted }} {{ row.chain.symbol }}
+              {% else %}
+              —
+              {% endif %}
+            </td>
+            <td>
+              {% if row.erc20_fiat_fee %}
+              {{ row.erc20_fiat_fee.formatted }} {{ row.erc20_fiat_fee.currency }}
               {% else %}
               —
               {% endif %}

--- a/api/app/templates/fees.html
+++ b/api/app/templates/fees.html
@@ -201,7 +201,7 @@
             </td>
             <td>
               {% if row.erc20 and row.erc20.fee.formatted %}
-              {{ row.erc20.fee.formatted }} {{ row.chain.symbol }}
+              {{ row.erc20.fee.formatted }} {{ row.erc20.token_symbol or row.chain.symbol }}
               {% else %}
               —
               {% endif %}

--- a/api/app/templates/fees.html
+++ b/api/app/templates/fees.html
@@ -159,6 +159,8 @@
             <th>Gas Price (Gwei)</th>
             <th>ガス量</th>
             <th>手数料</th>
+            <th>ERC20 ガス量</th>
+            <th>ERC20 手数料</th>
             <th>法定手数料</th>
             <th>モード</th>
             <th>ステータス</th>
@@ -179,6 +181,20 @@
             <td>
               {% if row.native_fee %}
               {{ row.native_fee.formatted }} {{ row.chain.symbol }}
+              {% else %}
+              —
+              {% endif %}
+            </td>
+            <td>
+              {% if row.erc20 %}
+              {{ row.erc20.gas_limit or '—' }}
+              {% else %}
+              —
+              {% endif %}
+            </td>
+            <td>
+              {% if row.erc20 and row.erc20.fee.formatted %}
+              {{ row.erc20.fee.formatted }} {{ row.chain.symbol }}
               {% else %}
               —
               {% endif %}

--- a/api/tests/test_fees.py
+++ b/api/tests/test_fees.py
@@ -96,6 +96,7 @@ async def test_fees_endpoint_returns_payload(client):
     assert first["erc20"]["gas_limit"] == 55000
     assert first["erc20"]["fee"]["formatted"].startswith("0.000165")
     assert first["erc20"]["token_symbol"] == "WBTC"
+    assert first["erc20_fiat_fee"] is None
 
 
 @pytest.mark.asyncio
@@ -206,6 +207,7 @@ async def test_stale_snapshot_returns_when_rpc_fails(client):
     assert "***" in debug_msg
     assert avax_row["erc20"]["gas_limit"] == 55000
     assert avax_row["erc20"]["token_symbol"] == "WBTC"
+    assert avax_row["erc20_fiat_fee"] is None
 
 
 @pytest.mark.asyncio
@@ -270,6 +272,7 @@ async def test_linea_estimate_gas_accepts_int_payload(client):
     assert linea_row["notes"] == "linea_estimateGas, feeHistory(p50)+maxPriority"
     assert linea_row["erc20"]["gas_limit"] == 55000
     assert linea_row["erc20"]["token_symbol"] == "WBTC"
+    assert linea_row.get("erc20_fiat_fee") is None
 
 
 @pytest.mark.asyncio
@@ -312,6 +315,7 @@ async def test_fees_endpoint_with_fiat_currency(client):
     assert payload["meta"]["fiat_requested"] == "USD"
     ethereum_row = next(row for row in payload["data"] if row["chain"]["key"] == "ethereum")
     assert ethereum_row["fiat_fee"]["formatted"] == "0.1260"
+    assert ethereum_row["erc20_fiat_fee"]["formatted"] == "0.3300"
     # Ensure fallback symbol uses ETH for arbitrum/optimism/linea
     arbitrum_row = next(row for row in payload["data"] if row["chain"]["key"] == "arbitrum")
     assert arbitrum_row["fiat_fee"]["price_symbol"] == "ETH"

--- a/api/tests/test_fees.py
+++ b/api/tests/test_fees.py
@@ -93,6 +93,8 @@ async def test_fees_endpoint_returns_payload(client):
     first = data[0]
     assert first["gas_price"]["gwei"] == "3.0000"
     assert first["native_fee"]["formatted"].startswith("0.000063")
+    assert first["erc20"]["gas_limit"] == 55000
+    assert first["erc20"]["fee"]["formatted"].startswith("0.000165")
 
 
 @pytest.mark.asyncio
@@ -201,6 +203,7 @@ async def test_stale_snapshot_returns_when_rpc_fails(client):
     debug_msg = avax_row.get("debug_error", "")
     assert "infura.io/v3" not in debug_msg
     assert "***" in debug_msg
+    assert avax_row["erc20"]["gas_limit"] == 55000
 
 
 @pytest.mark.asyncio
@@ -263,6 +266,7 @@ async def test_linea_estimate_gas_accepts_int_payload(client):
     linea_row = next(row for row in data if row["chain"]["key"] == "linea")
     assert linea_row["gas_limit"] == 21000
     assert linea_row["notes"] == "linea_estimateGas, feeHistory(p50)+maxPriority"
+    assert linea_row["erc20"]["gas_limit"] == 55000
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_fees.py
+++ b/api/tests/test_fees.py
@@ -95,6 +95,7 @@ async def test_fees_endpoint_returns_payload(client):
     assert first["native_fee"]["formatted"].startswith("0.000063")
     assert first["erc20"]["gas_limit"] == 55000
     assert first["erc20"]["fee"]["formatted"].startswith("0.000165")
+    assert first["erc20"]["token_symbol"] == "WBTC"
 
 
 @pytest.mark.asyncio
@@ -204,6 +205,7 @@ async def test_stale_snapshot_returns_when_rpc_fails(client):
     assert "infura.io/v3" not in debug_msg
     assert "***" in debug_msg
     assert avax_row["erc20"]["gas_limit"] == 55000
+    assert avax_row["erc20"]["token_symbol"] == "WBTC"
 
 
 @pytest.mark.asyncio
@@ -267,6 +269,7 @@ async def test_linea_estimate_gas_accepts_int_payload(client):
     assert linea_row["gas_limit"] == 21000
     assert linea_row["notes"] == "linea_estimateGas, feeHistory(p50)+maxPriority"
     assert linea_row["erc20"]["gas_limit"] == 55000
+    assert linea_row["erc20"]["token_symbol"] == "WBTC"
 
 
 @pytest.mark.asyncio

--- a/dailyreport/2025-09-26.md
+++ b/dailyreport/2025-09-26.md
@@ -30,3 +30,4 @@
 - Gas/Fee キャッシュ TTL を 10 分、価格キャッシュ TTL を 1 時間に延長し、`refresh=1` で強制再取得できるよう調整。
 - `_effective_gas_price` を `eth_feeHistory` の reward から priority を算出する形に変更し、RPC 呼び出し回数を削減（`eth_maxPriorityFeePerGas` は reward 欠損時のみ呼ぶ）。
 - ERC-20 送金時のガス量・手数料を同時算出し、JSON 応答と HTML テーブルに ERC20 列を追加。
+- ERC20 対象を WBTC と定義し、トークン記号を表示できるようデータ整形を追加。

--- a/dailyreport/2025-09-26.md
+++ b/dailyreport/2025-09-26.md
@@ -31,3 +31,4 @@
 - `_effective_gas_price` を `eth_feeHistory` の reward から priority を算出する形に変更し、RPC 呼び出し回数を削減（`eth_maxPriorityFeePerGas` は reward 欠損時のみ呼ぶ）。
 - ERC-20 送金時のガス量・手数料を同時算出し、JSON 応答と HTML テーブルに ERC20 列を追加。
 - ERC20 対象を WBTC と定義し、トークン記号を表示できるようデータ整形を追加。
+- ERC20 法定通貨手数料を追加し、テーブルを Native / Fiat / ERC20 / ERC20 Fiat の順に再配置。

--- a/dailyreport/2025-09-26.md
+++ b/dailyreport/2025-09-26.md
@@ -29,3 +29,4 @@
 - CoinMarketCap 取得を TTL キャッシュし、pytest で Fiat 換算のレスポンス内容を検証。
 - Gas/Fee キャッシュ TTL を 10 分、価格キャッシュ TTL を 1 時間に延長し、`refresh=1` で強制再取得できるよう調整。
 - `_effective_gas_price` を `eth_feeHistory` の reward から priority を算出する形に変更し、RPC 呼び出し回数を削減（`eth_maxPriorityFeePerGas` は reward 欠損時のみ呼ぶ）。
+- ERC-20 送金時のガス量・手数料を同時算出し、JSON 応答と HTML テーブルに ERC20 列を追加。

--- a/doc/実装計画書.md
+++ b/doc/実装計画書.md
@@ -145,7 +145,7 @@ repo-root/
 3. `gasPriceWei = baseFee + priority`（失敗時 `eth_gasPrice`）
 4. `gasGwei = gasPriceWei / 1e9`
 5. `fee_native = gasGwei / 1e9 * gasUsed`
-6. ERC‑20 送金は `gas_used = chain.erc20_gas_limit`（既定 55,000）で同単価を適用
+6. ERC‑20 (WBTC) 送金は `gas_used = chain.erc20_gas_limit`（既定 55,000）で同単価を適用
 7. 任意：CoinMarketCap API で USD/JPY へ換算（`fiat=usd|jpy`）
 
 ### 5.3 Gas 取得（precise β）
@@ -164,8 +164,8 @@ repo-root/
 ### 5.5 フロント
 
 * 起動時とユーザ操作（手動更新・間隔変更）で `/api/fees?...` を叩く。
-* テーブル列：Chain / Gas(Gwei) / GasUsed / Fee(native) / ERC20 Gas / ERC20 Fee / Fee(USD|JPY)
-* `/fees/?format=html` では JPY を既定表示とし、トグルから `USD`／`JPY` を切り替えて CoinMarketCap 由来の価格を表示（価格は 1 時間キャッシュ、更新ボタンで強制再取得）。
+* テーブル列：Chain / Gas(Gwei) / GasUsed / Fee(native) / Fee(USD|JPY) / ERC20 Gas / ERC20 Fee
+* `/fees/?format=html` では JPY を既定表示とし、トグルから `USD`／`JPY` を切り替えて CoinMarketCap 由来の価格を表示（価格は 1 時間キャッシュ、更新ボタンで強制再取得）。ERC-20 手数料は WBTC 送金を基準に概算する。
 * 並び替え（Gwei 昇順など）・コピー機能（行/全体）
 
 ---

--- a/doc/実装計画書.md
+++ b/doc/実装計画書.md
@@ -145,7 +145,8 @@ repo-root/
 3. `gasPriceWei = baseFee + priority`（失敗時 `eth_gasPrice`）
 4. `gasGwei = gasPriceWei / 1e9`
 5. `fee_native = gasGwei / 1e9 * gasUsed`
-6. 任意：CoinMarketCap API で USD/JPY へ換算（`fiat=usd|jpy`）
+6. ERC‑20 送金は `gas_used = chain.erc20_gas_limit`（既定 55,000）で同単価を適用
+7. 任意：CoinMarketCap API で USD/JPY へ換算（`fiat=usd|jpy`）
 
 ### 5.3 Gas 取得（precise β）
 
@@ -163,7 +164,7 @@ repo-root/
 ### 5.5 フロント
 
 * 起動時とユーザ操作（手動更新・間隔変更）で `/api/fees?...` を叩く。
-* テーブル列：Chain / Gas(Gwei) / GasUsed / Fee(native) / Fee(USD|JPY)
+* テーブル列：Chain / Gas(Gwei) / GasUsed / Fee(native) / ERC20 Gas / ERC20 Fee / Fee(USD|JPY)
 * `/fees/?format=html` では JPY を既定表示とし、トグルから `USD`／`JPY` を切り替えて CoinMarketCap 由来の価格を表示（価格は 1 時間キャッシュ、更新ボタンで強制再取得）。
 * 並び替え（Gwei 昇順など）・コピー機能（行/全体）
 

--- a/shared/chains.json
+++ b/shared/chains.json
@@ -8,7 +8,8 @@
     "native_gas_limit": 21000,
     "infura_network": "mainnet",
     "fee_model": "l1",
-    "price_symbol": "ETH"
+    "price_symbol": "ETH",
+    "erc20_token_symbol": "WBTC"
   },
   {
     "key": "polygon",
@@ -19,7 +20,8 @@
     "native_gas_limit": 21000,
     "infura_network": "polygon-mainnet",
     "fee_model": "l1",
-    "price_symbol": "POL"
+    "price_symbol": "POL",
+    "erc20_token_symbol": "WBTC"
   },
   {
     "key": "arbitrum",
@@ -30,7 +32,8 @@
     "native_gas_limit": 21000,
     "infura_network": "arbitrum-mainnet",
     "fee_model": "arbitrum",
-    "price_symbol": "ETH"
+    "price_symbol": "ETH",
+    "erc20_token_symbol": "WBTC"
   },
   {
     "key": "optimism",
@@ -41,7 +44,8 @@
     "native_gas_limit": 21000,
     "infura_network": "optimism-mainnet",
     "fee_model": "optimism",
-    "price_symbol": "ETH"
+    "price_symbol": "ETH",
+    "erc20_token_symbol": "WBTC"
   },
   {
     "key": "avalanche",
@@ -52,7 +56,8 @@
     "native_gas_limit": 21000,
     "infura_network": "avalanche-mainnet",
     "fee_model": "l1",
-    "price_symbol": "AVAX"
+    "price_symbol": "AVAX",
+    "erc20_token_symbol": "WBTC"
   },
   {
     "key": "linea",
@@ -63,6 +68,7 @@
     "native_gas_limit": 21000,
     "infura_network": "linea-mainnet",
     "fee_model": "linea",
-    "price_symbol": "ETH"
+    "price_symbol": "ETH",
+    "erc20_token_symbol": "WBTC"
   }
 ]


### PR DESCRIPTION
## Summary
- add ERC20 gas/fee calculations (WBTC baseline) to `/fees` responses and ensure cached rows include ERC20 data
- compute ERC20 fiat fees alongside native fiat fees, and rework the HTML table to show them in order: native → fiat → ERC20 → ERC20 fiat
- update docs, shared chain metadata, and daily report for the new WBTC-based ERC20 metrics

## Testing
- . .venv/bin/activate && python -m pytest
